### PR TITLE
Distinguishing platforms for running the poppler subprocess

### DIFF
--- a/pdf_utils/pdf_handler.py
+++ b/pdf_utils/pdf_handler.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 from pathlib import Path
 from tempfile import mkdtemp
+from sys import platform
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
@@ -140,8 +141,14 @@ class Pdf:
         if page_idx is not None:
             pdftotext_args.extend(["-f", str(page_idx + 1), "-l", str(page_idx + 1)])
 
-        return subprocess.check_output(
-            pdftotext_args + [str(self.pdf_path), "-"], universal_newlines=True)
+        if platform == "linux" or platform == "darwin":
+            return subprocess.check_output(
+                pdftotext_args + [str(self.pdf_path), "-"], universal_newlines=True)
+        elif platform == "win32":
+            return subprocess.check_output(
+                pdftotext_args + [str(self.pdf_path), "-"], universal_newlines=True, shell=True, encoding='UTF-8')
+        else:
+            logging.error("System not recognized")
 
     @property
     def simple_text(self) -> str:

--- a/pdf_utils/pdf_handler.py
+++ b/pdf_utils/pdf_handler.py
@@ -7,8 +7,8 @@ import logging
 import shutil
 import subprocess
 from pathlib import Path
-from tempfile import mkdtemp
 from sys import platform
+from tempfile import mkdtemp
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np


### PR DESCRIPTION
Poppler subprocess now distinguishes the platform and it's run according to the platform (fix was done especially for the Windows users).